### PR TITLE
The count query for a SimpleDBQuery is now generated correctly.

### DIFF
--- a/core/src/main/java/com/spaceprogram/simplejpa/query/SimpleDBQuery.java
+++ b/core/src/main/java/com/spaceprogram/simplejpa/query/SimpleDBQuery.java
@@ -32,7 +32,7 @@ public class SimpleDBQuery extends AbstractQuery {
         this.originalQuery = originalQuery;
     }
 
-    private static String extractClassFromQuery(String originalQuery) {
+    static String extractClassFromQuery(String originalQuery) {
         Matcher m  = CLASS_REGEX.matcher(originalQuery);
         if (!m.find()) {
         	throw new IllegalArgumentException("Could not determine domain class from query: " + originalQuery);
@@ -51,12 +51,12 @@ public class SimpleDBQuery extends AbstractQuery {
         AmazonQueryString aq = createAmazonQuery();
         if(aq.isCount()) return Integer.parseInt(getSingleResult().toString());
 
-        String countQuery = convertToCountQuery();
+        String countQuery = convertToCountQuery(originalQuery);
         
         return Integer.parseInt(new SimpleDBQuery(em, countQuery, tClass).getSingleResult().toString());
     }
 
-    private String convertToCountQuery() {
+    public static String convertToCountQuery(String originalQuery) {
         Matcher m = COUNT_REGEX.matcher(originalQuery);
         if (!m.find()) throw new IllegalArgumentException("Can not convert query to a count query: " + originalQuery);
         String replaceGroup = m.group(1);

--- a/core/src/test/java/com/spaceprogram/simplejpa/query/SimpleDBQueryTests.java
+++ b/core/src/test/java/com/spaceprogram/simplejpa/query/SimpleDBQueryTests.java
@@ -28,7 +28,7 @@ public class SimpleDBQueryTests extends UnitilsJUnit4 {
         SimpleDBQuery q = new SimpleDBQuery(mockEM.getMock(), "select count(*) from MyTestObject");
         AmazonQueryString aq = q.createAmazonQuery(false);
         assertTrue(aq.isCount());
-        assertEquals("select count(*) from simplddbquerytests-MyTestObject", aq.getValue());
+        assertEquals("select count(*) from `simplddbquerytests-MyTestObject`", aq.getValue());
     }
 
     @Test
@@ -41,7 +41,7 @@ public class SimpleDBQueryTests extends UnitilsJUnit4 {
         q.setParameter("val1", "value1");
         AmazonQueryString aq = q.createAmazonQuery(false);
         assertTrue(aq.isCount());
-        assertEquals("select count(*) from simplddbquerytests-MyTestObject where col1 = 'value1'", aq.getValue());
+        assertEquals("select count(*) from `simplddbquerytests-MyTestObject` where col1 = 'value1'", aq.getValue());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class SimpleDBQueryTests extends UnitilsJUnit4 {
         q.setParameter("val1", 10);
         AmazonQueryString aq = q.createAmazonQuery(false);
         assertTrue(aq.isCount());
-        assertEquals("select count(*) from simplddbquerytests-MyTestObject where col1 = '09223372036854775818'", aq.getValue());
+        assertEquals("select count(*) from `simplddbquerytests-MyTestObject` where col1 = '09223372036854775818'", aq.getValue());
     }
 
     @Test
@@ -68,7 +68,7 @@ public class SimpleDBQueryTests extends UnitilsJUnit4 {
         q.setParameter("val1", now);
         AmazonQueryString aq = q.createAmazonQuery(false);
         assertTrue(aq.isCount());
-        assertEquals("select count(*) from simplddbquerytests-MyTestObject where col1 = '"+ AmazonSimpleDBUtil.encodeDate(now)+"'", aq.getValue());
+        assertEquals("select count(*) from `simplddbquerytests-MyTestObject` where col1 = '"+ AmazonSimpleDBUtil.encodeDate(now)+"'", aq.getValue());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class SimpleDBQueryTests extends UnitilsJUnit4 {
         q.setParameter("val10", 10);
         AmazonQueryString aq = q.createAmazonQuery(false);
         assertFalse(aq.isCount());
-        String expected = new StringBuilder().append("select * from simplddbquerytests-MyTestObject where col1 = '")
+        String expected = new StringBuilder().append("select * from `simplddbquerytests-MyTestObject` where col1 = '")
                 .append(AmazonSimpleDBUtil.encodeDate(now))
                 .append("' and col10 > '09223372036854775818'").toString();
         assertEquals(expected, aq.getValue());
@@ -91,20 +91,20 @@ public class SimpleDBQueryTests extends UnitilsJUnit4 {
 
     @Test
     public void testConvertToCountQuery() {
-        AmazonQueryString aq = new AmazonQueryString("select * from DomainClass", false);
-        assertEquals("select count(*) from DomainClass", SimpleDBQuery.convertToCountQuery(aq));
+        String q = "select * from DomainClass";
+        assertEquals("select count(*) from DomainClass", SimpleDBQuery.convertToCountQuery(q));
     }
 
     @Test
     public void testConvertCountToCountQuery() {
-        AmazonQueryString aq = new AmazonQueryString("select count(*) from DomainClass", true);
-        assertEquals("select count(*) from DomainClass", SimpleDBQuery.convertToCountQuery(aq));
+    	String q = "select count(*) from DomainClass";
+        assertEquals("select count(*) from DomainClass", SimpleDBQuery.convertToCountQuery(q));
     }
 
     @Test
     public void testConvertFieldQueryToCount() {
-        AmazonQueryString aq = new AmazonQueryString("select itemName(), col1, col2 from DomainClass", true);
-        assertEquals("select count(*) from DomainClass", SimpleDBQuery.convertToCountQuery(aq));
+    	String q = "select itemName(), col1, col2 from DomainClass";
+        assertEquals("select count(*) from DomainClass", SimpleDBQuery.convertToCountQuery(q));
     }
 
     @Test


### PR DESCRIPTION
The count query for a SimpleDBQuery is now generated correctly.

The new query created by getCount() expected a query in the native format, not a query that already had the entity replaced.
